### PR TITLE
Work even if no prefix is set; use a default-default author name.

### DIFF
--- a/ep_auth_author.js
+++ b/ep_auth_author.js
@@ -73,12 +73,7 @@ exports.authenticate = function(hook_name, context, cb) {
 	var username = userpass.shift();
 	var password = userpass.join(':');
 
-	var username_prefix = settings.ep_auth_author.prefix;
-
-	if (username_prefix === undefined) {
-	    return cb([false]);
-	}
-
+	var username_prefix = settings.ep_auth_author && settings.ep_auth_author.prefix || "";
 	var prefixed_username = username_prefix + username;
 	
 	if (settings.users[prefixed_username] != undefined && settings.users[prefixed_username].password == password) {
@@ -87,7 +82,7 @@ exports.authenticate = function(hook_name, context, cb) {
 
 	    return( userManager.getAuthor4Username(prefixed_username, function(err, authorId) {
 		logger.debug('retrieved authorId ' + authorId + ' for username ' + prefixed_username);
-		context.req.session.auth_author = initializeAuthAuthorState(prefixed_username, authorId, context.req.session.user.author_name);
+		context.req.session.auth_author = initializeAuthAuthorState(prefixed_username, authorId, context.req.session.user.author_name || username);
 		return cb([true]);
 	    }) );
 	    


### PR DESCRIPTION
If no prefix setting is provided, we can potentially still set the
author name field correctly, assuming etherpad-lite is modified to call
authenticator hooks before its default authenticator:
https://github.com/ether/etherpad-lite/pull/3297

Even if the above patch isn't applied, it's harmless to permit the plugin to
try to run without a prefix.

Also, if no author_name field is provided, just use the login username as
the default author name.

Together, these two changes mean that ep_auth_author will do something
useful even with no settings.json changes.